### PR TITLE
feat: improve meeting creation dialog

### DIFF
--- a/pages/meeting_creation_page.py
+++ b/pages/meeting_creation_page.py
@@ -2,6 +2,8 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import TimeoutException, ElementClickInterceptedException
 from pages.base_page import BasePage
+import mimetypes
+import os
 import time
 
 class MeetingCreationPage(BasePage):
@@ -14,7 +16,8 @@ class MeetingCreationPage(BasePage):
     MEETING_NAME_INPUT = (By.ID, "meeting_name")
     SUBMIT_BUTTON = (By.ID, "createNewMeetingBtn")
     CANCEL_BUTTON = (By.XPATH, '//*[@id=":r24:"]/button')
-    UPLOAD_INPUT = (By.ID, "createNewMeetingBtn")
+    UPLOAD_INPUT = (By.ID, "meeting_file")
+    CREATION_DIALOG = (By.ID, "meetingDialog")
     
     def select_meeting_type(self, meeting_type):
         """Select meeting type only if not already selected"""
@@ -63,12 +66,58 @@ class MeetingCreationPage(BasePage):
     def upload_file(self, file_path):
         """Upload file for meeting"""
         self.enter_text(self.UPLOAD_INPUT, file_path)
-    
+
+    def get_uploaded_file_type(self):
+        """Get uploaded file MIME type (audio/video)"""
+        try:
+            file_input = self.wait.until(
+                EC.presence_of_element_located(self.UPLOAD_INPUT)
+            )
+            file_path = file_input.get_attribute("value")
+            if not file_path:
+                return None
+            if os.name == "nt":
+                # Selenium on Windows returns path with backslashes
+                file_path = file_path.split("\\")[-1]
+            mime_type, _ = mimetypes.guess_type(file_path)
+            return mime_type.split("/")[0] if mime_type else None
+        except TimeoutException:
+            return None
+
     def create_meeting(self, meeting_name=""):
         """Finalize meeting creation"""
         if meeting_name:
             self.enter_text(self.MEETING_NAME_INPUT, meeting_name)
         self.click(self.SUBMIT_BUTTON)
+
+    def cancel_creation(self):
+        """Cancel meeting creation by clicking cancel and waiting for dialog to close"""
+        try:
+            self.click(self.CANCEL_BUTTON)
+            self.wait.until(EC.invisibility_of_element_located(self.CREATION_DIALOG))
+        except (TimeoutException, ElementClickInterceptedException):
+            return False
+        return True
+
+    def is_creation_dialog_open(self):
+        """Check if meeting creation dialog is visible"""
+        try:
+            return self.wait.until(
+                EC.visibility_of_element_located(self.CREATION_DIALOG)
+            ).is_displayed()
+        except TimeoutException:
+            return False
+
+    def get_meeting_name(self):
+        """Return current meeting name or default if empty"""
+        try:
+            element = self.wait.until(
+                EC.visibility_of_element_located(self.MEETING_NAME_INPUT)
+            )
+            name = element.get_attribute("value")
+            return name if name else "Untitled Meeting"
+        except TimeoutException:
+            return None
     
     def is_meeting_created(self):
         """Check if meeting was successfully created"""
@@ -101,7 +150,7 @@ class MeetingCreationPage(BasePage):
         )
         trigger.click()
         time.sleep(3)  # Wait after opening dialog
-        
+
         # Wait specifically for dialog animation to complete
         # self.wait.until(
         #     lambda d: "show" in d.find_element(


### PR DESCRIPTION
## Summary
- fix file upload locator
- add helpers for uploaded file type, meeting name, and dialog state
- support cancelling meeting creation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'selenium')*

------
https://chatgpt.com/codex/tasks/task_e_68a7d66b7a648329ba89bc5e54b72484