### PR TITLE
Handle missing defaults in meeting creation page

### DIFF
--- a/pages/meeting_creation_page.py
+++ b/pages/meeting_creation_page.py
@@ -22,7 +22,7 @@ class MeetingCreationPage(BasePage):
     
     def select_meeting_type(self, meeting_type):
         """Select meeting type only if not already selected"""
-        current_type = self.get_selected_meeting_type()
+        current_type = self.get_selected_meeting_type() or ""
         if current_type.lower() != meeting_type.lower():
             if meeting_type.lower() == "online":
                 self.click(self.MEETING_TYPE_ONLINE)
@@ -39,7 +39,7 @@ class MeetingCreationPage(BasePage):
     
     def select_language(self, language):
         """Select language only if not already selected"""
-        current_lang = self.get_selected_language()
+        current_lang = self.get_selected_language() or ""
         if current_lang.lower() != language.lower():
             if language.lower() == "indonesia":
                 self.click(self.LANGUAGE_INDONESIAN)

--- a/tests/test_meeting_creation_page_unit.py
+++ b/tests/test_meeting_creation_page_unit.py
@@ -1,0 +1,69 @@
+import sys
+import types
+from unittest.mock import MagicMock
+
+# Provide minimal selenium stubs if selenium is unavailable
+if 'selenium' not in sys.modules:
+    selenium = types.ModuleType('selenium')
+    sys.modules['selenium'] = selenium
+
+    common = types.ModuleType('selenium.common')
+    exceptions = types.ModuleType('selenium.common.exceptions')
+    class TimeoutException(Exception):
+        pass
+    class ElementClickInterceptedException(Exception):
+        pass
+    exceptions.TimeoutException = TimeoutException
+    exceptions.ElementClickInterceptedException = ElementClickInterceptedException
+    common.exceptions = exceptions
+    sys.modules['selenium.common'] = common
+    sys.modules['selenium.common.exceptions'] = exceptions
+
+    webdriver = types.ModuleType('selenium.webdriver')
+    webdriver.common = types.ModuleType('selenium.webdriver.common')
+    by = types.ModuleType('selenium.webdriver.common.by')
+    class By:
+        ID = 'id'
+        XPATH = 'xpath'
+    by.By = By
+    webdriver.common.by = by
+    support = types.ModuleType('selenium.webdriver.support')
+    support.expected_conditions = types.ModuleType('selenium.webdriver.support.expected_conditions')
+    ui = types.ModuleType('selenium.webdriver.support.ui')
+    class WebDriverWait:
+        def __init__(self, *args, **kwargs):
+            pass
+        def until(self, method):
+            return None
+    ui.WebDriverWait = WebDriverWait
+    support.ui = ui
+    webdriver.support = support
+    sys.modules['selenium.webdriver'] = webdriver
+    sys.modules['selenium.webdriver.common'] = webdriver.common
+    sys.modules['selenium.webdriver.common.by'] = by
+    sys.modules['selenium.webdriver.support'] = support
+    sys.modules['selenium.webdriver.support.expected_conditions'] = support.expected_conditions
+    sys.modules['selenium.webdriver.support.ui'] = ui
+
+from pages.meeting_creation_page import MeetingCreationPage
+
+def test_select_meeting_type_no_default():
+    """Should select meeting type when no default is chosen"""
+    page = MeetingCreationPage(MagicMock())
+    page.get_selected_meeting_type = MagicMock(return_value=None)
+    page.click = MagicMock()
+
+    page.select_meeting_type("Online")
+
+    page.click.assert_called_once_with(page.MEETING_TYPE_ONLINE)
+
+
+def test_select_language_no_default():
+    """Should select language when no default is chosen"""
+    page = MeetingCreationPage(MagicMock())
+    page.get_selected_language = MagicMock(return_value=None)
+    page.click = MagicMock()
+
+    page.select_language("English")
+
+    page.click.assert_called_once_with(page.LANGUAGE_ENGLISH)


### PR DESCRIPTION
## Summary
- Prevent `select_meeting_type` from calling `.lower()` on `None`
- Prevent `select_language` from calling `.lower()` on `None`
- Add unit tests verifying selection when nothing is pre-selected

## Testing
- `pytest tests/test_meeting_creation_page_unit.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8088571c88329b0ae85d1d6bb7932